### PR TITLE
Add check for event transmission packet in parse_event_response function

### DIFF
--- a/fastmodbuslibrary/fast_modbus_events.py
+++ b/fastmodbuslibrary/fast_modbus_events.py
@@ -8,6 +8,9 @@ class ModbusEventReader(ModbusCommon):
     """
 
     REQUEST_EVENTS_COMMAND = 0x10
+    COMMAND_EXTENDED = 0x46
+    SUBCOMMAND_EVENT_TRANSMISSION = 0x11
+    MIN_PACKET_LENGTH = 6
 
     def __init__(self, device: str, baudrate: int):
         """
@@ -30,9 +33,13 @@ class ModbusEventReader(ModbusCommon):
         Returns:
             dict: A structure containing packet data, including packet_info and events.
         """
-        if len(response) < 6:
+        if len(response) < self.MIN_PACKET_LENGTH:
             self.logger.debug("Received packet is too short.")
-            return {}  # Return an empty dictionary if the packet is less than 6 bytes
+            return {}
+
+        if response[1] != self.COMMAND_EXTENDED and response[2] != self.SUBCOMMAND_EVENT_TRANSMISSION:
+            self.logger.debug("Received packet is not an event transmission packet.")
+            return {}
 
         packet_info = {}  # Dictionary to store packet information
 


### PR DESCRIPTION
This pull request introduces a check in the `parse_event_response` function of the `fast_modbus_events.py` file to ensure that only event transmission packets are processed. If the packet does not match the expected format for event transmission, the function returns an empty dictionary and logs a debug message.

### Changes:
- Added a check at the beginning of the `parse_event_response` function to verify if the packet is an event transmission packet.
- Introduced constants `COMMAND_EXTENDED` and `SUBCOMMAND_EVENT_TRANSMISSION` for better readability and maintainability.
- Updated the function to return an empty dictionary and log a debug message if the packet is not an event transmission packet.