### PR TITLE
Create build_packages.yml

### DIFF
--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -1,0 +1,81 @@
+name: Build Packages
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build_windows:
+    runs-on: windows-latest
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyinstaller
+
+      - name: Build .exe package
+        run: |
+          pyinstaller --onefile fastmodbuslibrary/__init__.py --name fastmodbuslibrary.exe
+        shell: cmd
+
+      - name: Upload Windows artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: windows-package
+          path: dist/*.exe
+
+  build_debian:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential debhelper python3-setuptools
+
+      - name: Build .deb package
+        run: |
+          mkdir -p debian_package/DEBIAN
+          echo "Package: fastmodbuslibrary\nVersion: 1.0\nArchitecture: all\nMaintainer: Your Name <you@example.com>\nDescription: FastModbus library for Python" > debian_package/DEBIAN/control
+          mkdir -p debian_package/usr/local/lib/python3.8/dist-packages
+          python3 setup.py install --root=debian_package/usr/local/lib/python3.8/dist-packages
+          dpkg-deb --build debian_package
+
+      - name: Upload Debian artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: debian-package
+          path: debian_package.deb
+
+  build_arch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v2
+
+      - name: Install Arch package tools
+        run: sudo apt-get update && sudo apt-get install -y base-devel fakeroot
+
+      - name: Build .pkg.tar.zst package
+        run: |
+          mkdir -p arch_package/PKGBUILD
+          echo "pkgname=fastmodbuslibrary\npkgver=1.0\npkgrel=1\narch=('x86_64')\ndepends=('python')\nsource=('setup.py')\npackage() {\n  python3 setup.py install --root=\"\$pkgdir\"\n}" > arch_package/PKGBUILD
+          makepkg -f -p arch_package/PKGBUILD
+
+      - name: Upload Arch artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: arch-package
+          path: *.pkg.tar.zst


### PR DESCRIPTION
Automated Package Build Workflow for Windows, Debian, and Arch Linux

This pull request introduces a GitHub Actions workflow that automates the build process for packaging the project on multiple platforms:
- Windows (.exe) using PyInstaller
- Debian (.deb) with dpkg-deb
- Arch Linux (.pkg.tar.zst) using makepkg

Each build is triggered on pushes and pull requests to the main branch, ensuring packages are up-to-date and ready for deployment across environments.
