### PR TITLE
Add GitHub Actions workflow to upload Debian package to Releases

### DIFF
--- a/.github/workflows/test_and_build_debian_package.yml
+++ b/.github/workflows/test_and_build_debian_package.yml
@@ -44,7 +44,11 @@ jobs:
         id: check_version
         run: |
           # Get the latest tag
-          latest_tag=$(git describe --tags --abbrev=0)
+          latest_tag=$(git describe --tags --abbrev=0 2>/dev/null)
+          if [ -z "$latest_tag" ]; then
+            echo "No tags found. Assuming version has changed."
+            exit 0
+          fi
           echo "Latest tag: $latest_tag"
           # Extract the version from the latest tag
           latest_version=${latest_tag#v}

--- a/.github/workflows/test_and_build_debian_package.yml
+++ b/.github/workflows/test_and_build_debian_package.yml
@@ -24,14 +24,39 @@ jobs:
         with:
           python-version: '3.12'
 
-      # Step 3: Install necessary dependencies for running tests
+      # Step 3: Extract the version from setup.py and save it as an environment variable
+      - name: Extract version from setup.py
+        id: get_version
+        run: |
+          # Retrieve the version from setup.py
+          version=$(python setup.py --version)
+          echo "Package version: $version"
+          echo "version=$version" >> $GITHUB_ENV
+
+      # Step 4: Check if the version has changed
+      - name: Check version change
+        id: check_version
+        run: |
+          # Get the latest tag
+          latest_tag=$(git describe --tags --abbrev=0)
+          # Extract the version from the latest tag
+          latest_version=${latest_tag#v}
+          # Compare the current version with the latest version
+          if [ "${{ env.version }}" == "$latest_version" ]; then
+            echo "Version has not changed. Failing the workflow."
+            exit 1
+          else
+            echo "Version has changed. Proceeding with the workflow."
+          fi
+
+      # Step 5: Install necessary dependencies for running tests
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install pytest
 
-      # Step 4: Run tests
+      # Step 6: Run tests
       - name: Run Tests
         run: |
           export PYTHONPATH="${{ github.workspace }}:${PYTHONPATH}"
@@ -67,7 +92,13 @@ jobs:
           echo "Package version: $version"
           echo "version=$version" >> $GITHUB_ENV
 
-      # Step 5: Build the Debian package with the extracted version
+      # Step 5: Create a tag based on the extracted version
+      - name: Create tag
+        run: |
+          git tag -a "v${{ env.version }}" -m "Release v${{ env.version }}"
+          git push origin "v${{ env.version }}"
+
+      # Step 6: Build the Debian package with the extracted version
       - name: Build .deb package
         run: |
           mkdir -p debian_package/DEBIAN
@@ -81,14 +112,14 @@ jobs:
           python setup.py install --root=debian_package/usr/local
           dpkg-deb --build debian_package
 
-      # Step 6: Upload the Debian package as an artifact for later use
+      # Step 7: Upload the Debian package as an artifact for later use
       - name: Upload Debian Package
         uses: actions/upload-artifact@v3
         with:
           name: debian-package
           path: debian_package.deb
 
-      # Step 7: Upload the Debian package to GitHub Releases
+      # Step 8: Upload the Debian package to GitHub Releases
       - name: Upload to GitHub Releases
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/test_and_build_debian_package.yml
+++ b/.github/workflows/test_and_build_debian_package.yml
@@ -84,26 +84,32 @@ jobs:
     runs-on: ubuntu-latest
     needs: test  # Ensure build only runs after successful test completion
     steps:
-      # Step 1: Check out the repository code
+      # Step 1: Set up SSH agent
+      - name: Set up SSH agent
+        uses: webfactory/ssh-agent@v0.5.4
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+      # Step 2: Check out the repository code
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           persist-credentials: false
 
-      # Step 2: Set up the Python environment
+      # Step 3: Set up the Python environment
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: '3.12'
 
-      # Step 3: Install dependencies required for building the package
+      # Step 4: Install dependencies required for building the package
       - name: Install build dependencies
         run: |
           python -m pip install --upgrade pip
           pip install setuptools wheel  # Install setuptools to use setup.py
 
-      # Step 4: Extract the version from setup.py and save it as an environment variable
+      # Step 5: Extract the version from setup.py and save it as an environment variable
       - name: Extract version from setup.py
         id: get_version
         run: |
@@ -112,19 +118,19 @@ jobs:
           echo "Package version: $version"
           echo "version=$version" >> $GITHUB_ENV
 
-      # Step 5: Configure Git user
+      # Step 6: Configure Git user
       - name: Configure Git user
         run: |
           git config --global user.email "actions@github.com"
           git config --global user.name "GitHub Actions"
 
-      # Step 6: Create a tag based on the extracted version
+      # Step 7: Create a tag based on the extracted version
       - name: Create tag
         run: |
           git tag -a "v${{ env.version }}" -m "Release v${{ env.version }}"
           git push origin "v${{ env.version }}"
 
-      # Step 7: Build the Debian package with the extracted version
+      # Step 8: Build the Debian package with the extracted version
       - name: Build .deb package
         run: |
           mkdir -p debian_package/DEBIAN
@@ -138,14 +144,14 @@ jobs:
           python setup.py install --root=debian_package/usr/local
           dpkg-deb --build debian_package
 
-      # Step 8: Upload the Debian package as an artifact for later use
+      # Step 9: Upload the Debian package as an artifact for later use
       - name: Upload Debian Package
         uses: actions/upload-artifact@v3
         with:
           name: debian-package
           path: debian_package.deb
 
-      # Step 9: Upload the Debian package to GitHub Releases
+      # Step 10: Upload the Debian package to GitHub Releases
       - name: Upload to GitHub Releases
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/test_and_build_debian_package.yml
+++ b/.github/workflows/test_and_build_debian_package.yml
@@ -24,7 +24,13 @@ jobs:
         with:
           python-version: '3.12'
 
-      # Step 3: Extract the version from setup.py and save it as an environment variable
+      # Step 3: Install setuptools
+      - name: Install setuptools
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools
+
+      # Step 4: Extract the version from setup.py and save it as an environment variable
       - name: Extract version from setup.py
         id: get_version
         run: |
@@ -33,7 +39,7 @@ jobs:
           echo "Package version: $version"
           echo "version=$version" >> $GITHUB_ENV
 
-      # Step 4: Check if the version has changed
+      # Step 5: Check if the version has changed
       - name: Check version change
         id: check_version
         run: |
@@ -51,14 +57,14 @@ jobs:
             echo "Version has changed. Proceeding with the workflow."
           fi
 
-      # Step 5: Install necessary dependencies for running tests
+      # Step 6: Install necessary dependencies for running tests
       - name: Install test dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install pytest
 
-      # Step 6: Run tests
+      # Step 7: Run tests
       - name: Run unit tests
         run: |
           export PYTHONPATH="${{ github.workspace }}:${PYTHONPATH}"

--- a/.github/workflows/test_and_build_debian_package.yml
+++ b/.github/workflows/test_and_build_debian_package.yml
@@ -27,6 +27,11 @@ jobs:
         pip install -r requirements.txt
         pip install pytest setuptools wheel
 
+    - name: Install Package in Editable Mode
+      run: |
+        # Установка пакета в режиме разработки для доступности модулей
+        pip install -e .
+
     - name: Version Check
       run: |
         version=$(python setup.py --version | tr -d '[:space:]')

--- a/.github/workflows/test_and_build_debian_package.yml
+++ b/.github/workflows/test_and_build_debian_package.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Check version change
         id: check_version
         run: |
+          # Debug: Print the GITHUB_TOKEN
+          echo "GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}"
+
           # Get the latest tag
           latest_tag=$(git describe --tags --abbrev=0 2>/dev/null)
           if [ -z "$latest_tag" ]; then

--- a/.github/workflows/test_and_build_debian_package.yml
+++ b/.github/workflows/test_and_build_debian_package.yml
@@ -3,47 +3,15 @@ name: Build and Release
 on:
   push:
     branches:
-      - main  # Запускается только при пуше в ветку main
+      - main
 
   pull_request:
     branches:
-      - '*'  # Запускается для всех pull request, кроме main
-    paths-ignore:
-      - 'main'
+      - '*'
 
 jobs:
-  # Job 1: Version Check
-  version-check:
+  test_and_build:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
-
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.x'
-
-    - name: Install Core Dependencies
-      run: |
-        # Установка необходимых зависимостей для setup.py
-        pip install setuptools wheel
-
-    - name: Check Version in setup.py
-      id: version_check
-      run: |
-        # Извлечение версии из setup.py и сохранение для последующих шагов
-        version=$(python setup.py --version | tr -d '[:space:]')
-        echo "Version from setup.py is $version"
-        echo "::set-output name=version::$version"
-
-  # Job 2: Run Tests
-  tests:
-    runs-on: ubuntu-latest
-    needs: version-check  # Зависимость от успешного завершения version-check
-    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
 
     steps:
     - name: Checkout repository
@@ -56,67 +24,37 @@ jobs:
 
     - name: Install Dependencies
       run: |
-        # Установка зависимостей для тестов, включая pytest
         pip install -r requirements.txt
-        pip install pytest  # Установка pytest явно
-        # Установка тестовых зависимостей, если файл существует
-        if [ -f test-requirements.txt ]; then pip install -r test-requirements.txt; fi
+        pip install pytest setuptools wheel
 
-    - name: Install Package
+    - name: Version Check
       run: |
-        # Установка пакета в режиме разработки
-        pip install -e .
+        version=$(python setup.py --version | tr -d '[:space:]')
+        echo "Version is $version"
 
     - name: Run Tests
-      run: |
-        # Запуск тестов с использованием pytest
-        pytest tests/
-
-  # Job 3: Build Debian Package
-  build-package:
-    runs-on: ubuntu-latest
-    needs: tests  # Зависимость от успешного завершения tests
-    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
-
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.x'
-
-    - name: Install Core Dependencies
-      run: |
-        # Установка необходимых зависимостей для сборки пакета
-        pip install setuptools wheel
+      run: pytest tests/
 
     - name: Build Debian Package
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       run: |
-        # Сборка Debian пакета с использованием версии из setup.py
         version=$(python setup.py --version | tr -d '[:space:]')
         echo "Building Debian package version $version..."
-        # Предполагаем, что пакет будет называться debian_package_$version.deb
         # dpkg-deb --build my_package/ debian_package_${version}.deb
-        # Сохранение имени пакета для шага release
         echo "::set-output name=package_name::debian_package_${version}.deb"
 
-  # Job 4: Release on GitHub
   release:
     runs-on: ubuntu-latest
-    needs: build-package  # Зависимость от успешного завершения build-package
-    if: github.ref == 'refs/heads/main'  # Выполняется только при пуше в main
+    needs: test_and_build
+    if: github.ref == 'refs/heads/main'
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
 
     - name: Create Git Tag
-      id: create_tag
       run: |
-        # Использование версии из setup.py для создания тега
-        version="v${{ needs.version-check.outputs.version }}"
+        version="v${{ needs.test_and_build.outputs.version }}"
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
         git tag -a "$version" -m "Release $version"
@@ -125,8 +63,6 @@ jobs:
     - name: Release on GitHub
       uses: softprops/action-gh-release@v1
       with:
-        # Загрузка Debian пакета в релиз GitHub
-        files: debian_package_${{ needs.build-package.outputs.package_name }}
-        tag_name: ${{ steps.create_tag.outputs.version }}
+        files: debian_package_${{ needs.test_and_build.outputs.package_name }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test_and_build_debian_package.yml
+++ b/.github/workflows/test_and_build_debian_package.yml
@@ -115,10 +115,12 @@ jobs:
         else
           version="v${{ needs.version-check.outputs.version }}"
         fi
+        # Remove any spaces or newlines in the version variable
+        version=$(echo "$version" | tr -d '[:space:]')
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
-        git tag -a $version -m "Release $version"
-        git push origin $version --force
+        git tag -a "$version" -m "Release $version"
+        git push origin "$version" --force
 
     - name: Release on GitHub
       uses: softprops/action-gh-release@v1

--- a/.github/workflows/test_and_build_debian_package.yml
+++ b/.github/workflows/test_and_build_debian_package.yml
@@ -60,6 +60,11 @@ jobs:
         # Install test-specific dependencies if file exists
         if [ -f test-requirements.txt ]; then pip install -r test-requirements.txt; fi
 
+    - name: Install Package
+      run: |
+        # Install the package in editable mode
+        pip install -e .
+
     - name: Run Tests
       run: |
         # Run tests using pytest

--- a/.github/workflows/test_and_build_debian_package.yml
+++ b/.github/workflows/test_and_build_debian_package.yml
@@ -3,11 +3,11 @@ name: Build and Release
 on:
   push:
     branches:
-      - main  # Запуск при мерже в ветку main
+      - main  # Runs on merge to main branch
 
   pull_request:
     branches:
-      - '*'    # Запуск на пулл-реквесты в любые ветки, кроме main
+      - '*'  # Runs on pull requests to any branch except main
     paths-ignore:
       - 'main'
 
@@ -26,34 +26,35 @@ jobs:
 
     - name: Install Dependencies
       run: |
-        # Установка зависимостей для тестов
+        # Install general and test dependencies
         pip install -r requirements.txt
-        pip install -r test-requirements.txt
+        # Install test-specific dependencies if file exists
+        if [ -f test-requirements.txt ]; then pip install -r test-requirements.txt; fi
 
     - name: Check Version in setup.py
       id: version_check
       run: |
-        # Извлекаем версию из setup.py и передаем её дальше
+        # Extract version from setup.py and store it for later steps
         version=$(python setup.py --version)
         echo "Version from setup.py is $version"
         echo "::set-output name=version::$version"
 
     - name: Run Tests
       run: |
-        # Запуск тестов, например с использованием pytest
+        # Run tests using pytest
         pytest tests/
 
     - name: Build Debian Package
       run: |
-        # Сборка пакета, используя версию из setup.py
+        # Build the Debian package using the version from setup.py
         echo "Building Debian package version ${{ steps.version_check.outputs.version }}..."
-        # Предполагаем, что пакет будет назван с использованием версии, например:
+        # Assuming the package will be named with the extracted version
         # dpkg-deb --build my_package/ debian_package_${{ steps.version_check.outputs.version }}.deb
 
   release:
     runs-on: ubuntu-latest
-    needs: build-and-release  # Зависи от успешного выполнения build-and-release
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'  # Запускается только на мерж в main
+    needs: build-and-release  # Depends on successful build-and-release completion
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'  # Runs only on merge to main branch
 
     steps:
     - name: Checkout repository
@@ -61,6 +62,7 @@ jobs:
 
     - name: Create Git Tag
       run: |
+        # Configure Git and create a version tag
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
         git tag -a v${{ needs.build-and-release.outputs.version_check.version }} -m "Release version ${{ needs.build-and-release.outputs.version_check.version }}"
@@ -69,6 +71,7 @@ jobs:
     - name: Release on GitHub
       uses: softprops/action-gh-release@v1
       with:
+        # Upload the Debian package to GitHub Release
         files: debian_package_${{ needs.build-and-release.outputs.version_check.version }}.deb
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test_and_build_debian_package.yml
+++ b/.github/workflows/test_and_build_debian_package.yml
@@ -50,14 +50,14 @@ jobs:
           fi
 
       # Step 5: Install necessary dependencies for running tests
-      - name: Install dependencies
+      - name: Install test dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install pytest
 
       # Step 6: Run tests
-      - name: Run Tests
+      - name: Run unit tests
         run: |
           export PYTHONPATH="${{ github.workspace }}:${PYTHONPATH}"
           pytest tests/
@@ -78,7 +78,7 @@ jobs:
           python-version: '3.12'
 
       # Step 3: Install dependencies required for building the package
-      - name: Install dependencies for build
+      - name: Install build dependencies
         run: |
           python -m pip install --upgrade pip
           pip install setuptools wheel  # Install setuptools to use setup.py

--- a/.github/workflows/test_and_build_debian_package.yml
+++ b/.github/workflows/test_and_build_debian_package.yml
@@ -3,11 +3,11 @@ name: Build and Release
 on:
   push:
     branches:
-      - main  # Runs on push to main branch
+      - main  # Запускается при пуше в ветку main
 
   pull_request:
     branches:
-      - '*'  # Runs on all pull requests to any branch
+      - '*'  # Запускается при создании pull request в любую ветку
 
 jobs:
   # Job 1: Version Check
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set up Python
       uses: actions/setup-python@v2
@@ -25,13 +25,13 @@ jobs:
 
     - name: Install Core Dependencies
       run: |
-        # Install setuptools and wheel for setup.py
+        # Установка необходимых зависимостей для setup.py
         pip install setuptools wheel
 
     - name: Check Version in setup.py
       id: version_check
       run: |
-        # Extract version from setup.py and store it for later steps
+        # Извлечение версии из setup.py и сохранение для последующих шагов
         version=$(python setup.py --version)
         echo "Version from setup.py is $version"
         echo "::set-output name=version::$version"
@@ -39,11 +39,11 @@ jobs:
   # Job 2: Run Tests
   tests:
     runs-on: ubuntu-latest
-    needs: version-check  # Depends on the successful completion of version-check
+    needs: version-check  # Зависимость от успешного завершения version-check
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set up Python
       uses: actions/setup-python@v2
@@ -52,30 +52,30 @@ jobs:
 
     - name: Install Dependencies
       run: |
-        # Install general and test dependencies, including pytest
+        # Установка зависимостей для тестов, включая pytest
         pip install -r requirements.txt
-        pip install pytest  # Install pytest explicitly
-        # Install test-specific dependencies if file exists
+        pip install pytest  # Установка pytest явно
+        # Установка тестовых зависимостей, если файл существует
         if [ -f test-requirements.txt ]; then pip install -r test-requirements.txt; fi
 
     - name: Install Package
       run: |
-        # Install the package in editable mode
+        # Установка пакета в режиме разработки
         pip install -e .
 
     - name: Run Tests
       run: |
-        # Run tests using pytest
+        # Запуск тестов с использованием pytest
         pytest tests/
 
   # Job 3: Build Debian Package
   build-package:
     runs-on: ubuntu-latest
-    needs: tests  # Depends on the successful completion of tests
+    needs: tests  # Зависимость от успешного завершения tests
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set up Python
       uses: actions/setup-python@v2
@@ -84,38 +84,38 @@ jobs:
 
     - name: Install Core Dependencies
       run: |
-        # Install setuptools and wheel for setup.py
+        # Установка необходимых зависимостей для сборки пакета
         pip install setuptools wheel
 
     - name: Build Debian Package
       run: |
-        # Build the Debian package using the version from setup.py
+        # Сборка Debian пакета с использованием версии из setup.py
         version=$(python setup.py --version)
         echo "Building Debian package version $version..."
-        # Assuming the package will be named with the extracted version
+        # Предполагаем, что пакет будет называться debian_package_$version.deb
         # dpkg-deb --build my_package/ debian_package_${version}.deb
-        # Save package name to output for use in the release step
+        # Сохранение имени пакета для шага release
         echo "::set-output name=package_name::debian_package_${version}.deb"
 
   # Job 4: Release on GitHub
   release:
     runs-on: ubuntu-latest
-    needs: build-package  # Depends on the successful completion of build-package
+    needs: build-package  # Зависимость от успешного завершения build-package
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Create Git Tag
       id: create_tag
       run: |
-        # Set up a unique version tag for PRs and main branch
+        # Определение уникального тега для pull request и основной ветки
         if [ "${{ github.event_name }}" == "pull_request" ]; then
           version="${{ needs.version-check.outputs.version }}-PR${{ github.event.pull_request.number }}"
         else
           version="v${{ needs.version-check.outputs.version }}"
         fi
-        # Remove any spaces or newlines in the version variable
+        # Удаление лишних пробелов в переменной version
         version=$(echo "$version" | tr -d '[:space:]')
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -125,7 +125,7 @@ jobs:
     - name: Release on GitHub
       uses: softprops/action-gh-release@v1
       with:
-        # Upload the Debian package to GitHub Release
+        # Загрузка Debian пакета в релиз GitHub
         files: debian_package_${{ needs.build-package.outputs.package_name }}
         tag_name: ${{ steps.create_tag.outputs.version }}
       env:

--- a/.github/workflows/test_and_build_debian_package.yml
+++ b/.github/workflows/test_and_build_debian_package.yml
@@ -3,13 +3,11 @@ name: Build and Release
 on:
   push:
     branches:
-      - main  # Runs on merge to main branch
+      - main  # Runs on push to main branch
 
   pull_request:
     branches:
-      - '*'  # Runs on pull requests to any branch except main
-    paths-ignore:
-      - 'main'
+      - '*'  # Runs on all pull requests to any branch
 
 jobs:
   # Job 1: Version Check
@@ -103,7 +101,6 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: build-package  # Depends on the successful completion of build-package
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'  # Runs only on merge to main branch
 
     steps:
     - name: Checkout repository
@@ -111,17 +108,22 @@ jobs:
 
     - name: Create Git Tag
       run: |
-        # Configure Git and create a version tag
-        version=$(python setup.py --version)
+        # Set up a unique version tag for PRs and main branch
+        if [ "${{ github.event_name }}" == "pull_request" ]; then
+          version="${{ needs.version-check.outputs.version }}-PR${{ github.event.pull_request.number }}"
+        else
+          version="v${{ needs.version-check.outputs.version }}"
+        fi
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
-        git tag -a v${version} -m "Release version ${version}"
-        git push origin v${version}
+        git tag -a $version -m "Release $version" -f
+        git push origin $version -f  # Force-push to overwrite existing tag if it exists
 
     - name: Release on GitHub
       uses: softprops/action-gh-release@v1
       with:
         # Upload the Debian package to GitHub Release
         files: debian_package_${{ needs.build-package.outputs.package_name }}
+        tag_name: ${{ steps.create_tag.outputs.version }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test_and_build_debian_package.yml
+++ b/.github/workflows/test_and_build_debian_package.yml
@@ -54,8 +54,9 @@ jobs:
 
     - name: Install Dependencies
       run: |
-        # Install general and test dependencies
+        # Install general and test dependencies, including pytest
         pip install -r requirements.txt
+        pip install pytest  # Install pytest explicitly
         # Install test-specific dependencies if file exists
         if [ -f test-requirements.txt ]; then pip install -r test-requirements.txt; fi
 

--- a/.github/workflows/test_and_build_debian_package.yml
+++ b/.github/workflows/test_and_build_debian_package.yml
@@ -1,10 +1,13 @@
 name: Test and Build Debian Package
 
-# Trigger workflow only on pull requests for any branch
+# Trigger workflow on pull requests for any branch and on pushes to the main branch
 on:
   pull_request:
     branches:
       - '**'
+  push:
+    branches:
+      - 'main'
 
 jobs:
   test:
@@ -84,3 +87,11 @@ jobs:
         with:
           name: debian-package
           path: debian_package.deb
+
+      # Step 7: Upload the Debian package to GitHub Releases
+      - name: Upload to GitHub Releases
+        uses: softprops/action-gh-release@v1
+        with:
+          files: debian_package.deb
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test_and_build_debian_package.yml
+++ b/.github/workflows/test_and_build_debian_package.yml
@@ -1,159 +1,59 @@
-name: Test and Build Debian Package
+name: Build and Release
 
-# Trigger workflow on pull requests for any branch and on pushes to the main branch
 on:
-  pull_request:
-    branches:
-      - '**'
   push:
     branches:
-      - 'main'
+      - main  # Запускается при пуше в ветку main
 
 jobs:
-  test:
-    # Define the environment for the test job
+  build-and-release:
     runs-on: ubuntu-latest
+
     steps:
-      # Step 1: Check out the repository code
-      - name: Checkout code
-        uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          persist-credentials: false
+    - name: Checkout repository
+      uses: actions/checkout@v2
 
-      # Step 2: Set up the Python environment
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.12'
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
 
-      # Step 3: Install setuptools
-      - name: Install setuptools
-        run: |
-          python -m pip install --upgrade pip
-          pip install setuptools
+    - name: Install Dependencies
+      run: |
+        # Установка зависимостей для тестов
+        pip install -r requirements.txt
+        pip install -r test-requirements.txt
 
-      # Step 4: Extract the version from setup.py and save it as an environment variable
-      - name: Extract version from setup.py
-        id: get_version
-        run: |
-          # Retrieve the version from setup.py
-          version=$(python setup.py --version)
-          echo "Package version: $version"
-          echo "version=$version" >> $GITHUB_ENV
+    - name: Check Version in setup.py
+      id: version_check
+      run: |
+        # Извлекаем версию из setup.py и передаем её дальше
+        version=$(python setup.py --version)
+        echo "Version from setup.py is $version"
+        echo "::set-output name=version::$version"
 
-      # Step 5: Check if the version has changed
-      - name: Check version change
-        id: check_version
-        run: |
-          # Get the latest tag using GitHub API
-          latest_tag=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            "https://api.github.com/repos/${{ github.repository }}/tags" | \
-            jq -r '.[0].name')
-          if [ -z "$latest_tag" ]; then
-            echo "No tags found. Assuming version has changed."
-            exit 0
-          fi
-          echo "Latest tag: $latest_tag"
-          # Extract the version from the latest tag
-          latest_version=${latest_tag#v}
-          echo "Latest version: $latest_version"
-          # Compare the current version with the latest version
-          if [ "${{ env.version }}" == "$latest_version" ]; then
-            echo "Version has not changed. Failing the workflow."
-            exit 1
-          else
-            echo "Version has changed. Proceeding with the workflow."
-          fi
+    - name: Run Tests
+      run: |
+        # Запуск тестов, например с использованием pytest
+        pytest tests/
 
-      # Step 6: Install necessary dependencies for running tests
-      - name: Install test dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install pytest
+    - name: Build Debian Package
+      run: |
+        # Сборка пакета, используя версию из setup.py
+        echo "Building Debian package version ${{ steps.version_check.outputs.version }}..."
+        # Предполагаем, что пакет будет назван с использованием версии, например:
+        # dpkg-deb --build my_package/ debian_package_${{ steps.version_check.outputs.version }}.deb
 
-      # Step 7: Run tests
-      - name: Run unit tests
-        run: |
-          export PYTHONPATH="${{ github.workspace }}:${PYTHONPATH}"
-          pytest tests/
+    - name: Create Git Tag
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git tag -a v${{ steps.version_check.outputs.version }} -m "Release version ${{ steps.version_check.outputs.version }}"
+        git push origin v${{ steps.version_check.outputs.version }}
 
-  build:
-    # Define the environment for the build job
-    runs-on: ubuntu-latest
-    needs: test  # Ensure build only runs after successful test completion
-    steps:
-      # Step 1: Set up SSH agent
-      - name: Set up SSH agent
-        uses: webfactory/ssh-agent@v0.5.4
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-
-      # Step 2: Check out the repository code using SSH
-      - name: Checkout code
-        uses: actions/checkout@v3
-        with:
-          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
-
-      # Step 3: Set up the Python environment
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.12'
-
-      # Step 4: Install dependencies required for building the package
-      - name: Install build dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install setuptools wheel  # Install setuptools to use setup.py
-
-      # Step 5: Extract the version from setup.py and save it as an environment variable
-      - name: Extract version from setup.py
-        id: get_version
-        run: |
-          # Retrieve the version from setup.py
-          version=$(python setup.py --version)
-          echo "Package version: $version"
-          echo "version=$version" >> $GITHUB_ENV
-
-      # Step 6: Configure Git user
-      - name: Configure Git user
-        run: |
-          git config --global user.email "actions@github.com"
-          git config --global user.name "GitHub Actions"
-
-      # Step 7: Create a tag based on the extracted version
-      - name: Create tag
-        run: |
-          git tag -a "v${{ env.version }}" -m "Release v${{ env.version }}"
-          git push origin "v${{ env.version }}"
-
-      # Step 8: Build the Debian package with the extracted version
-      - name: Build .deb package
-        run: |
-          mkdir -p debian_package/DEBIAN
-          echo "Package: fastmodbuslibrary" > debian_package/DEBIAN/control
-          echo "Version: ${{ env.version }}" >> debian_package/DEBIAN/control
-          echo "Section: base" >> debian_package/DEBIAN/control
-          echo "Priority: optional" >> debian_package/DEBIAN/control
-          echo "Architecture: all" >> debian_package/DEBIAN/control
-          echo "Maintainer: Aleksandr Degtyarev <adegtyarev.ap@gmail.com>" >> debian_package/DEBIAN/control
-          echo "Description: Fast Modbus Python Library" >> debian_package/DEBIAN/control
-          python setup.py install --root=debian_package/usr/local
-          dpkg-deb --build debian_package
-
-      # Step 9: Upload the Debian package as an artifact for later use
-      - name: Upload Debian Package
-        uses: actions/upload-artifact@v3
-        with:
-          name: debian-package
-          path: debian_package.deb
-
-      # Step 10: Upload the Debian package to GitHub Releases
-      - name: Upload to GitHub Releases
-        uses: softprops/action-gh-release@v1
-        with:
-          files: debian_package.deb
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Release on GitHub
+      uses: softprops/action-gh-release@v1
+      with:
+        files: debian_package_${{ steps.version_check.outputs.version }}.deb
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test_and_build_debian_package.yml
+++ b/.github/workflows/test_and_build_debian_package.yml
@@ -45,11 +45,10 @@ jobs:
       - name: Check version change
         id: check_version
         run: |
-          # Debug: Print the GITHUB_TOKEN
-          echo "GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}"
-
-          # Get the latest tag
-          latest_tag=$(git describe --tags --abbrev=0 2>/dev/null)
+          # Get the latest tag using GitHub API
+          latest_tag=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/${{ github.repository }}/tags" | \
+            jq -r '.[0].name')
           if [ -z "$latest_tag" ]; then
             echo "No tags found. Assuming version has changed."
             exit 0

--- a/.github/workflows/test_and_build_debian_package.yml
+++ b/.github/workflows/test_and_build_debian_package.yml
@@ -39,8 +39,10 @@ jobs:
         run: |
           # Get the latest tag
           latest_tag=$(git describe --tags --abbrev=0)
+          echo "Latest tag: $latest_tag"
           # Extract the version from the latest tag
           latest_version=${latest_tag#v}
+          echo "Latest version: $latest_version"
           # Compare the current version with the latest version
           if [ "${{ env.version }}" == "$latest_version" ]; then
             echo "Version has not changed. Failing the workflow."

--- a/.github/workflows/test_and_build_debian_package.yml
+++ b/.github/workflows/test_and_build_debian_package.yml
@@ -110,13 +110,19 @@ jobs:
           echo "Package version: $version"
           echo "version=$version" >> $GITHUB_ENV
 
-      # Step 5: Create a tag based on the extracted version
+      # Step 5: Configure Git user
+      - name: Configure Git user
+        run: |
+          git config --global user.email "actions@github.com"
+          git config --global user.name "GitHub Actions"
+
+      # Step 6: Create a tag based on the extracted version
       - name: Create tag
         run: |
           git tag -a "v${{ env.version }}" -m "Release v${{ env.version }}"
           git push origin "v${{ env.version }}"
 
-      # Step 6: Build the Debian package with the extracted version
+      # Step 7: Build the Debian package with the extracted version
       - name: Build .deb package
         run: |
           mkdir -p debian_package/DEBIAN
@@ -130,14 +136,14 @@ jobs:
           python setup.py install --root=debian_package/usr/local
           dpkg-deb --build debian_package
 
-      # Step 7: Upload the Debian package as an artifact for later use
+      # Step 8: Upload the Debian package as an artifact for later use
       - name: Upload Debian Package
         uses: actions/upload-artifact@v3
         with:
           name: debian-package
           path: debian_package.deb
 
-      # Step 8: Upload the Debian package to GitHub Releases
+      # Step 9: Upload the Debian package to GitHub Releases
       - name: Upload to GitHub Releases
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/test_and_build_debian_package.yml
+++ b/.github/workflows/test_and_build_debian_package.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
 
       # Step 2: Set up the Python environment
       - name: Set up Python
@@ -88,6 +89,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
 
       # Step 2: Set up the Python environment
       - name: Set up Python

--- a/.github/workflows/test_and_build_debian_package.yml
+++ b/.github/workflows/test_and_build_debian_package.yml
@@ -12,8 +12,36 @@ on:
       - 'main'
 
 jobs:
-  build-and-release:
+  # Job 1: Version Check
+  version-check:
     runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Install Core Dependencies
+      run: |
+        # Install setuptools and wheel for setup.py
+        pip install setuptools wheel
+
+    - name: Check Version in setup.py
+      id: version_check
+      run: |
+        # Extract version from setup.py and store it for later steps
+        version=$(python setup.py --version)
+        echo "Version from setup.py is $version"
+        echo "::set-output name=version::$version"
+
+  # Job 2: Run Tests
+  tests:
+    runs-on: ubuntu-latest
+    needs: version-check  # Depends on the successful completion of version-check
 
     steps:
     - name: Checkout repository
@@ -31,29 +59,44 @@ jobs:
         # Install test-specific dependencies if file exists
         if [ -f test-requirements.txt ]; then pip install -r test-requirements.txt; fi
 
-    - name: Check Version in setup.py
-      id: version_check
-      run: |
-        # Extract version from setup.py and store it for later steps
-        version=$(python setup.py --version)
-        echo "Version from setup.py is $version"
-        echo "::set-output name=version::$version"
-
     - name: Run Tests
       run: |
         # Run tests using pytest
         pytest tests/
 
+  # Job 3: Build Debian Package
+  build-package:
+    runs-on: ubuntu-latest
+    needs: tests  # Depends on the successful completion of tests
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Install Core Dependencies
+      run: |
+        # Install setuptools and wheel for setup.py
+        pip install setuptools wheel
+
     - name: Build Debian Package
       run: |
         # Build the Debian package using the version from setup.py
-        echo "Building Debian package version ${{ steps.version_check.outputs.version }}..."
+        version=$(python setup.py --version)
+        echo "Building Debian package version $version..."
         # Assuming the package will be named with the extracted version
-        # dpkg-deb --build my_package/ debian_package_${{ steps.version_check.outputs.version }}.deb
+        # dpkg-deb --build my_package/ debian_package_${version}.deb
+        # Save package name to output for use in the release step
+        echo "::set-output name=package_name::debian_package_${version}.deb"
 
+  # Job 4: Release on GitHub
   release:
     runs-on: ubuntu-latest
-    needs: build-and-release  # Depends on successful build-and-release completion
+    needs: build-package  # Depends on the successful completion of build-package
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'  # Runs only on merge to main branch
 
     steps:
@@ -63,15 +106,16 @@ jobs:
     - name: Create Git Tag
       run: |
         # Configure Git and create a version tag
+        version=$(python setup.py --version)
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
-        git tag -a v${{ needs.build-and-release.outputs.version_check.version }} -m "Release version ${{ needs.build-and-release.outputs.version_check.version }}"
-        git push origin v${{ needs.build-and-release.outputs.version_check.version }}
+        git tag -a v${version} -m "Release version ${version}"
+        git push origin v${version}
 
     - name: Release on GitHub
       uses: softprops/action-gh-release@v1
       with:
         # Upload the Debian package to GitHub Release
-        files: debian_package_${{ needs.build-and-release.outputs.version_check.version }}.deb
+        files: debian_package_${{ needs.build-package.outputs.package_name }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test_and_build_debian_package.yml
+++ b/.github/workflows/test_and_build_debian_package.yml
@@ -17,6 +17,8 @@ jobs:
       # Step 1: Check out the repository code
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       # Step 2: Set up the Python environment
       - name: Set up Python
@@ -82,6 +84,8 @@ jobs:
       # Step 1: Check out the repository code
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       # Step 2: Set up the Python environment
       - name: Set up Python

--- a/.github/workflows/test_and_build_debian_package.yml
+++ b/.github/workflows/test_and_build_debian_package.yml
@@ -5,10 +5,17 @@ on:
     branches:
       - main  # Запускается только при пуше в ветку main
 
+  pull_request:
+    branches:
+      - '*'  # Запускается для всех pull request, кроме main
+    paths-ignore:
+      - 'main'
+
 jobs:
   # Job 1: Version Check
   version-check:
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
 
     steps:
     - name: Checkout repository
@@ -36,6 +43,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     needs: version-check  # Зависимость от успешного завершения version-check
+    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
 
     steps:
     - name: Checkout repository
@@ -68,6 +76,7 @@ jobs:
   build-package:
     runs-on: ubuntu-latest
     needs: tests  # Зависимость от успешного завершения tests
+    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/test_and_build_debian_package.yml
+++ b/.github/workflows/test_and_build_debian_package.yml
@@ -3,11 +3,7 @@ name: Build and Release
 on:
   push:
     branches:
-      - main  # Запускается при пуше в ветку main
-
-  pull_request:
-    branches:
-      - '*'  # Запускается при создании pull request в любую ветку
+      - main  # Запускается только при пуше в ветку main
 
 jobs:
   # Job 1: Version Check
@@ -101,6 +97,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: build-package  # Зависимость от успешного завершения build-package
+    if: github.ref == 'refs/heads/main'  # Выполняется только при пуше в main
 
     steps:
     - name: Checkout repository
@@ -109,12 +106,8 @@ jobs:
     - name: Create Git Tag
       id: create_tag
       run: |
-        # Определение уникального тега для pull request и основной ветки
-        if [ "${{ github.event_name }}" == "pull_request" ]; then
-          version="${{ needs.version-check.outputs.version }}-PR${{ github.event.pull_request.number }}"
-        else
-          version="v${{ needs.version-check.outputs.version }}"
-        fi
+        # Использование версии из setup.py для создания тега
+        version="v${{ needs.version-check.outputs.version }}"
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
         git tag -a "$version" -m "Release $version"

--- a/.github/workflows/test_and_build_debian_package.yml
+++ b/.github/workflows/test_and_build_debian_package.yml
@@ -3,7 +3,13 @@ name: Build and Release
 on:
   push:
     branches:
-      - main  # Запускается при пуше в ветку main
+      - main  # Запуск при мерже в ветку main
+
+  pull_request:
+    branches:
+      - '*'    # Запуск на пулл-реквесты в любые ветки, кроме main
+    paths-ignore:
+      - 'main'
 
 jobs:
   build-and-release:
@@ -44,16 +50,25 @@ jobs:
         # Предполагаем, что пакет будет назван с использованием версии, например:
         # dpkg-deb --build my_package/ debian_package_${{ steps.version_check.outputs.version }}.deb
 
+  release:
+    runs-on: ubuntu-latest
+    needs: build-and-release  # Зависи от успешного выполнения build-and-release
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'  # Запускается только на мерж в main
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
     - name: Create Git Tag
       run: |
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
-        git tag -a v${{ steps.version_check.outputs.version }} -m "Release version ${{ steps.version_check.outputs.version }}"
-        git push origin v${{ steps.version_check.outputs.version }}
+        git tag -a v${{ needs.build-and-release.outputs.version_check.version }} -m "Release version ${{ needs.build-and-release.outputs.version_check.version }}"
+        git push origin v${{ needs.build-and-release.outputs.version_check.version }}
 
     - name: Release on GitHub
       uses: softprops/action-gh-release@v1
       with:
-        files: debian_package_${{ steps.version_check.outputs.version }}.deb
+        files: debian_package_${{ needs.build-and-release.outputs.version_check.version }}.deb
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test_and_build_debian_package.yml
+++ b/.github/workflows/test_and_build_debian_package.yml
@@ -107,6 +107,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Create Git Tag
+      id: create_tag
       run: |
         # Set up a unique version tag for PRs and main branch
         if [ "${{ github.event_name }}" == "pull_request" ]; then
@@ -116,8 +117,8 @@ jobs:
         fi
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
-        git tag -a $version -m "Release $version" -f
-        git push origin $version -f  # Force-push to overwrite existing tag if it exists
+        git tag -a $version -m "Release $version"
+        git push origin $version --force
 
     - name: Release on GitHub
       uses: softprops/action-gh-release@v1

--- a/.github/workflows/test_and_build_debian_package.yml
+++ b/.github/workflows/test_and_build_debian_package.yml
@@ -32,7 +32,7 @@ jobs:
       id: version_check
       run: |
         # Извлечение версии из setup.py и сохранение для последующих шагов
-        version=$(python setup.py --version)
+        version=$(python setup.py --version | tr -d '[:space:]')
         echo "Version from setup.py is $version"
         echo "::set-output name=version::$version"
 
@@ -90,7 +90,7 @@ jobs:
     - name: Build Debian Package
       run: |
         # Сборка Debian пакета с использованием версии из setup.py
-        version=$(python setup.py --version)
+        version=$(python setup.py --version | tr -d '[:space:]')
         echo "Building Debian package version $version..."
         # Предполагаем, что пакет будет называться debian_package_$version.deb
         # dpkg-deb --build my_package/ debian_package_${version}.deb
@@ -115,8 +115,6 @@ jobs:
         else
           version="v${{ needs.version-check.outputs.version }}"
         fi
-        # Удаление лишних пробелов в переменной version
-        version=$(echo "$version" | tr -d '[:space:]')
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
         git tag -a "$version" -m "Release $version"

--- a/.github/workflows/test_and_build_debian_package.yml
+++ b/.github/workflows/test_and_build_debian_package.yml
@@ -90,12 +90,11 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
-      # Step 2: Check out the repository code
+      # Step 2: Check out the repository code using SSH
       - name: Checkout code
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          persist-credentials: false
+          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       # Step 3: Set up the Python environment
       - name: Set up Python

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='fastmodbuslibrary',
-    version='0.1.0',
+    version='0.1.1',
     packages=find_packages(),
     install_requires=[
         'pyserial',


### PR DESCRIPTION
This pull request enhances the GitHub Actions workflow by adding a version change check before running tests. If the version in `setup.py` has not changed, the workflow will fail. Additionally, it creates a tag based on the version extracted from `setup.py` and uploads the Debian package to GitHub Releases.